### PR TITLE
Handle trailing whitespace in a nested array

### DIFF
--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -68,7 +68,7 @@ class JSONParser:
             return self.parse_json()
         # If everything else fails, then we give up and return an exception
         else:
-            raise ValueError(f"Invalid JSON format")
+            raise ValueError("Invalid JSON format")
 
     def parse_object(self):
         # <object> ::= '{' [ <member> *(', ' <member>) ] '}' ; A sequence of 'members'

--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -63,12 +63,12 @@ class JSONParser:
         elif char.isalpha():
             return self.parse_string()
         # Ignore whitespaces outside of strings
-        elif char == " ":
+        elif char.isspace():
             self.index += 1
             return self.parse_json()
         # If everything else fails, then we give up and return an exception
         else:
-            raise ValueError("Invalid JSON format")
+            raise ValueError(f"Invalid JSON format")
 
     def parse_object(self):
         # <object> ::= '{' [ <member> *(', ' <member>) ] '}' ; A sequence of 'members'
@@ -128,6 +128,10 @@ class JSONParser:
         while (char := self.get_char_at()) != "]" and char is not False:
             value = self.parse_json()
             arr.append(value)
+
+            # skip over whitespace after a value but before closing ]
+            while (char := self.get_char_at()) is not False and char.isspace():
+                self.index += 1
 
             if self.get_char_at() == ",":
                 self.index += 1

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -41,6 +41,7 @@ def test_repair_json():
     # Test with edge cases
     assert repair_json(" ") == '""'
     assert repair_json("[") == "[]"
+    assert repair_json("[[1\n\n]") == "[[1]]"
     assert repair_json("{") == "{}"
     assert repair_json('{"key": "value:value"}') == '{"key": "value:value"}'
     assert (


### PR DESCRIPTION
Issue #1

---------

## What is the current behavior?
Doesn't handle whitespace before a trailing ] in a nested array, meaning JSON which could otherwise be fixed generates an error.

## What is the new behavior?
- fixes the above issue
- add test case

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
