### PR TITLE
support for number-like strings

### DIFF
--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -245,13 +245,16 @@ class JSONParser:
             self.index += 1
             char = self.get_char_at()
         if number_str:
-            if "." in number_str or "e" in number_str or "E" in number_str:
-                return float(number_str)
-            elif number_str == "-":
-                # If there is a stray "-" this will throw an exception, throw away this character
-                return self.parse_json()
-            else:
-                return int(number_str)
+            try:
+                if "." in number_str or "e" in number_str or "E" in number_str:
+                    return float(number_str)
+                elif number_str == "-":
+                    # If there is a stray "-" this will throw an exception, throw away this character
+                    return self.parse_json()
+                else:
+                    return int(number_str)
+            except ValueError:
+                return number_str
         else:
             # This is a string then
             return self.parse_string()

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -191,6 +191,10 @@ def test_repair_json_corner_cases_generate_by_gpt():
     # Test with null values
     assert repair_json('{"key": null}') == '{"key": null}'
 
+    # Test with numeric-like values
+    assert repair_json('{"key": 10-20}') == '{"key": "10-20"}'
+    assert repair_json('{"key": 1.1.1}') == '{"key": "1.1.1"}'
+
 
 def test_repair_json_corner_cases_generate_by_gpt_with_objects():
     # Test with nested JSON
@@ -220,6 +224,10 @@ def test_repair_json_corner_cases_generate_by_gpt_with_objects():
 
     # Test with null values
     assert repair_json('{"key": null}', True) == {"key": None}
+
+    # Test with numeric-like values
+    assert repair_json('{"key": 10-20}', True) == {"key": "10-20"}
+    assert repair_json('{"key": 1.1.1}', True) == {"key": "1.1.1"}
 
 def test_repair_json_skip_json_loads():
     assert repair_json('{"key": true, "key2": false, "key3": null}', skip_json_loads=True) == '{"key": true, "key2": false, "key3": null}'


### PR DESCRIPTION
Issue #

---------
## What is the current behavior?
Strings that begin with a number and contain number-like characters (e.g., 10-20, 1.1.1) are not successfully parsed

## What is the new behavior?
They are! :-) 

## Does this introduce a breaking change?

- [ ] Yes
- [X ] No



## Other information
See tests