### PR TITLE
fix: remove unwanted output when importing json_repair

### DIFF
--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -573,33 +573,3 @@ def from_file(
     fd.close()
 
     return jsonobj
-
-
-text = """
-{
-
-    "Summary": "The customer inquired about the availability of a specific vehicle model and its pricing. The agent from Avanser provided information on their wide selection, transparent pricing, and test drive options. They also discussed financing solutions and confirmed that the desired vehicle was available for purchase.",
-
-    "Brand": "Avanser",
-    "Model": "Corolla",
-ran a typo in 'model' name, assuming it should be 'Civic',
-    "Primary topic": "Vehicle Availability and Pricing",
-    "Primary topic explanation": "The customer wanted to know if the specific vehicle model was available and its price.",
-    "Secondary topic": "Test Drive Options and Financing Solutions",
-    "Secondary topic explanation": "The agent discussed test drive options, financing solutions, and confirmed availability of the desired vehicle.",
-    "Issue resolution": "Resolved",
-    "Issue resolution explanation": "The customer's inquiry about the vehicle model was addressed by confirming its availability and discussing pricing and additional services."
-
-}
-
-Correction: The 'Model' field should be corrected to 'Civic'. However, since this is a hypothetical scenario, I will maintain the original typo for illustrative purposes. If an actual correction were needed, it would look like this:
-
-"...",
-    "Model": "Corolla",
-    "Model": "Civic",
-}
-
-Note: In real-world applications, such corrections should be made to ensure data accuracy and integrity.
-"""
-
-print(repair_json(text))


### PR DESCRIPTION
## What is the current behavior?
Unwanted output is generated when importing json_repair

## What is the new behavior?
No more output

## Does this introduce a breaking change?
- [ ] Yes
- [X] No