### PR TITLE
Feature: Fix plain ellipsis (...) in arrays

### DIFF
--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -172,6 +172,20 @@ class JSONParser:
         # Stop when you either find the closing parentheses or you have iterated over the entire string
         while (self.get_char_at() or "]") != "]":
             self.skip_whitespaces_at()
+            # Check for ellipsis '...' and skip it if present
+            if (
+                self.get_char_at() == "."
+                and self.get_char_at(1) == "."
+                and self.get_char_at(2) == "."
+            ):
+                self.index += 3  # Skip the ellipsis
+                self.skip_whitespaces_at()
+                # Continue parsing if there's more after the ellipsis, otherwise break
+                if self.get_char_at() in [",", " "]:
+                    continue
+                else:
+                    break
+
             value = self.parse_json()
 
             # It is possible that parse_json() returns nothing valid, so we stop

--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -172,27 +172,16 @@ class JSONParser:
         # Stop when you either find the closing parentheses or you have iterated over the entire string
         while (self.get_char_at() or "]") != "]":
             self.skip_whitespaces_at()
-            # Check for ellipsis '...' and skip it if present
-            if (
-                self.get_char_at() == "."
-                and self.get_char_at(1) == "."
-                and self.get_char_at(2) == "."
-            ):
-                self.index += 3  # Skip the ellipsis
-                self.skip_whitespaces_at()
-                # Continue parsing if there's more after the ellipsis, otherwise break
-                if self.get_char_at() in [",", " "]:
-                    continue
-                else:
-                    break
-
             value = self.parse_json()
 
             # It is possible that parse_json() returns nothing valid, so we stop
             if not value:
                 break
 
-            arr.append(value)
+            if value == "..." and self.get_char_at(-1) == ".":
+                self.log("While parsing an array, found '...'; ignoring it", "info")
+            else:
+                arr.append(value)
 
             # skip over whitespace after a value but before closing ]
             char = self.get_char_at()

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -27,6 +27,14 @@ def test_repair_json():
         == '{"name": "John", "age": 30, "city": "New York"}'
     )
     assert (
+        repair_json('{"name": "John", "age": 30, "city": "New York", ...}')
+        == '{"name": "John", "age": 30, "city": "New York"}'
+    )
+    assert (
+        repair_json('{"name": "John", "age": 30, ..., "city": "New York"}')
+        == '{"name": "John", "age": 30, "city": "New York"}'
+    )
+    assert (
         repair_json('{"name": "John", "age": 30, city: "New York"}')
         == '{"name": "John", "age": 30, "city": "New York"}'
     )
@@ -39,6 +47,8 @@ def test_repair_json():
         == '{"name": "John", "age": 30, "city": "New York"}'
     )
     assert repair_json("[1, 2, 3,") == "[1, 2, 3]"
+    assert repair_json("[1, 2, 3, ...]") == "[1, 2, 3]"
+    assert repair_json("[1, 2, ..., 3]") == "[1, 2, 3]"
     assert (
         repair_json('{"employees":["John", "Anna",')
         == '{"employees": ["John", "Anna"]}'
@@ -146,6 +156,16 @@ def test_repair_json_with_objects():
         "age": 30,
         "city": "New York",
     }
+    assert repair_json('{"name": "John", "age": 30, "city": "New York", ...}', return_objects=True) == {
+        "name": "John",
+        "age": 30,
+        "city": "New York",
+    }
+    assert repair_json('{"name": "John", "age": 30, ..., "city": "New York"}', return_objects=True) == {
+        "name": "John",
+        "age": 30,
+        "city": "New York",
+    }
     assert repair_json('{"name": "John", "age": 30, city: "New York"}', return_objects=True) == {
         "name": "John",
         "age": 30,
@@ -157,6 +177,8 @@ def test_repair_json_with_objects():
         "city": "New York",
     }
     assert repair_json("[1, 2, 3,", return_objects=True) == [1, 2, 3]
+    assert repair_json("[1, 2, 3, ...]", return_objects=True) == [1, 2, 3]
+    assert repair_json("[1, 2, ..., 3]", return_objects=True) == [1, 2, 3]
     assert repair_json('{"employees":["John", "Anna",', return_objects=True) == {
         "employees": ["John", "Anna"]
     }


### PR DESCRIPTION
## What is the current behavior?
Currently, the ellipsis are turned into a string:
`[1, 2, ...]` -> `[1, 2, "..."]`

## What is the new behavior?
`[1, 2, ...]` -> `[1, 2]`

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
- [X] Potentially, IFF users are relying on the ellipsis being turned into a string (unlikely)

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
