### PR TITLE
[FEATURE] Adding [ensure_ascii] option to [repair_json] 

### DIFF
--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -675,6 +675,7 @@ def repair_json(
     skip_json_loads: Optional[bool] = False,
     logging: Optional[bool] = False,
     json_fd: Optional[TextIO] = None,
+    ensure_ascii: Optional[bool] = False,
 ) -> Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]]]:
     """
     Given a json formatted string, it will try to decode it and, if it fails, it will try to fix it.
@@ -697,7 +698,7 @@ def repair_json(
     # It's useful to return the actual object instead of the json string, it allows this lib to be a replacement of the json library
     if return_objects or logging:
         return parsed_json
-    return json.dumps(parsed_json)
+    return json.dumps(parsed_json, ensure_ascii=ensure_ascii)
 
 
 def loads(


### PR DESCRIPTION
…on-ascii characters

Issue #

---------

I was trying to repaire a json string return by llm, it returns in Chinese, and the response of [repair_json] is in unicode.