### PR TITLE
added check for integer being key in object

### DIFF
--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -301,7 +301,7 @@ class JSONParser:
 
         char = self.get_char_at()
         # A valid string can only start with a valid quote or, in our case, with a literal
-        while char and char not in ['"', "'", "“"] and not char.isalpha():
+        while char and char not in ['"', "'", "“"] and not char.isalnum():
             self.index += 1
             char = self.get_char_at()
 
@@ -315,7 +315,7 @@ class JSONParser:
         elif char == "“":
             lstring_delimiter = "“"
             rstring_delimiter = "”"
-        elif char.isalpha():
+        elif char.isalnum():
             # This could be a <boolean> and not a string. Because (T)rue or (F)alse or (N)ull are valid
             # But remember, object keys are only of type string
             if char.lower() in ["t", "f", "n"] and self.get_context() != "object_key":

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -96,6 +96,7 @@ def test_missing_and_mixed_quotes():
     )
     assert repair_json('[{"key": "value", COMMENT "notes": "lorem "ipsum", sic."}]') == '[{"key": "value", "notes": "lorem \\"ipsum\\", sic."}]'
     assert repair_json('{"key": ""value"}') == '{"key": "value"}'
+    assert repair_json('{"key": "value", 5: "value"}') == '{"key": "value", "5": "value"}'
 
 def test_array_edge_cases():
     assert repair_json("[1, 2, 3,") == "[1, 2, 3]"


### PR DESCRIPTION
previous behaviour:
data = '{42:{"key":"value", "key2":"value2"}}'

repair_json(data) -> '{"key":"value", "key2":"value2"}'

new behaviour:
repair_json(data) -> '{"42":{"key":"value", "key2":"value2"}}'

Issue #

---------

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->
bugfix
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently repair_json fixes missing quotes only for alpha keys, however alphanumeric are also valid keys
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
repair_json also fixes alphanumeric keys missing quotes
-
-
-

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
