### PR TITLE
Add edge case for number

### DIFF
--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -179,6 +179,7 @@ def test_number_edge_cases():
     assert repair_json('{"key": 10-20}') == '{"key": "10-20"}'
     assert repair_json('{"key": 1.1.1}') == '{"key": "1.1.1"}'
     assert repair_json('[- ') == '[]'
+    assert repair_json('{"key": 6this is following text."}') == '{"key": "6this is following text."}'
 
 def test_markdown():
     assert repair_json('{ "content": "[LINK]("https://google.com")" }') == '{"content": "[LINK](\\"https://google.com\\")"}'


### PR DESCRIPTION
## Proposed changes

Fix a bug in `parse_number` method to correctly handle cases where a digit is immediately followed by alphabetic characters (e.g., `6this`). Previously, the parser would treat these as invalid numbers, but they should be treated as unquoted strings. The fix detects when a number is followed directly by alphabetic characters and rolls back to the start position, passing the entire token to `parse_string` for proper handling.

This change specifically addresses the test case with `{"key": 6this is following text."}`, ensuring it's properly repaired to `{"key": "6this is following text."}`.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangiucugna/json_repair/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run pre-commit and unit tests and all pass locally with my changes

## Further comments

The fix involves adding logic to the `parse_number` method to detect when a number-like token is followed immediately by alphabetic characters, indicating it's actually an unquoted string that starts with digits. When this pattern is detected, we roll back to the start position and treat the entire token as a string.

Alternative approaches considered:
1. Modifying `parse_json` to check for numeric characters followed by alpha, but this would require more complex lookahead
2. Modifying the string parsing logic to handle numeric prefixes, but this would complicate an already complex method

The chosen approach is minimal and encapsulated within the `parse_number` method, which is the appropriate place to handle this edge case.

fixes #106
