### PR TITLE
Add stream_stable parameter to support repairing those streaming json accumulated at a certain moment

### DIFF
--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -38,6 +38,7 @@ def repair_json(
     json_fd: Optional[TextIO] = None,
     ensure_ascii: bool = True,
     chunk_length: int = 0,
+    stream_stable: bool = False,
 ) -> Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]]]:
     """
     Given a json formatted string, it will try to decode it and, if it fails, it will try to fix it.
@@ -50,11 +51,11 @@ def repair_json(
         json_fd (Optional[TextIO], optional): File descriptor for JSON input. Do not use! Use `from_file` or `load` instead. Defaults to None.
         ensure_ascii (bool, optional): Set to False to avoid converting non-latin characters to ascii (for example when using chinese characters). Defaults to True. Ignored if `skip_json_loads` is True.
         chunk_length (int, optional): Size in bytes of the file chunks to read at once. Ignored if `json_fd` is None. Do not use! Use `from_file` or `load` instead. Defaults to 1MB.
-
+        stream_stable (bool, optional): When the json to be repaired is the accumulation of streaming json at a certain moment.If this parameter to True will keep the repair results stable.
     Returns:
         Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]]]: The repaired JSON or a tuple with the repaired JSON and repair log.
     """
-    parser = JSONParser(json_str, json_fd, logging, chunk_length)
+    parser = JSONParser(json_str, json_fd, logging, chunk_length, stream_stable)
     if skip_json_loads:
         parsed_json = parser.parse()
     else:

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -299,6 +299,20 @@ def test_ensure_ascii():
     assert repair_json("{'test_中国人_ascii':'统一码'}", ensure_ascii=False) == '{"test_中国人_ascii": "统一码"}'
 
 
+def test_stream_stable():
+    # default: stream_stable = False
+    # When the json to be repaired is the accumulation of streaming json at a certain moment.
+    # The default repair result is unstable.
+    assert repair_json('{"key": "val\\', stream_stable=False) == '{"key": "val\\\\"}'
+    assert repair_json('{"key": "val\\n', stream_stable=False) == '{"key": "val"}'
+    assert repair_json('{"key": "val\\n123,`key2:value2', stream_stable=False) == '{"key": "val\\n123", "key2": "value2"}'
+    assert repair_json('{"key": "val\\n123,`key2:value2`"}', stream_stable=True) == '{"key": "val\\n123,`key2:value2`"}'
+    # stream_stable = True
+    assert repair_json('{"key": "val\\', stream_stable=True) == '{"key": "val"}'
+    assert repair_json('{"key": "val\\n', stream_stable=True) == '{"key": "val\\n"}'
+    assert repair_json('{"key": "val\\n123,`key2:value2', stream_stable=True) == '{"key": "val\\n123,`key2:value2"}'
+    assert repair_json('{"key": "val\\n123,`key2:value2`"}', stream_stable=True) == '{"key": "val\\n123,`key2:value2`"}'
+
 
 def test_cli(capsys):
     # Create a temporary file


### PR DESCRIPTION
## Proposed changes

We use this library to repair the json of llm response, which is a streaming output.
We do not wait for the llm response to complete the call to repair json, but instead perform repair json once for each character output by llm.
In this case, we found that the repair json function is unstable:

```python
    assert repair_json('{"key": "val\\') == '{"key": "val\\\\"}'
    assert repair_json('{"key": "val\\n') == '{"key": "val"}'
    assert repair_json('{"key": "val\\n123,`key2:value2') == '{"key": "val\\n123", "key2": "value2"}'
    assert repair_json('{"key": "val\\n123,`key2:value2`"}') == '{"key": "val\\n123,`key2:value2`"}'
```

We expect:

```python
    assert repair_json('{"key": "val\\') == '{"key": "val"}'
    assert repair_json('{"key": "val\\n') == '{"key": "val\\n"}'
    assert repair_json('{"key": "val\\n123,`key2:value2') == '{"key": "val\\n123,`key2:value2"}'
    assert repair_json('{"key": "val\\n123,`key2:value2`"}') == '{"key": "val\\n123,`key2:value2`"}'
```

* Ignore extra escape characters at the end of an unclosed string `\`.
* Keep extra whitespace characters at the end of the unclosed string.
* An unclosed string is not parsed to produce more object key values.


## Types of changes

- [x] New feature - `repair_json` and `JSONParser.__init__` add `stream_stable` optional parameter.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangiucugna/json_repair/blob/master/CONTRIBUTING.md) doc.
- [x] I have added tests that prove my fix is effective or that my feature works (see `tests/test_json_repair.py@test_stream_stable`).
- [x] I have run pre-commit and unit tests and all pass locally with my changes.

## Further comments

Considering compatibility, I implemented the requirement by adding a new parameter.
