### PR TITLE
Add overloads for repair_json function to support different return types based on return_objects parameter

### DIFF
--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -25,9 +25,35 @@ All supported use cases are in the unit tests
 import argparse
 import json
 import sys
-from typing import Dict, List, Optional, TextIO, Tuple, Union
+from typing import Dict, List, Literal, Optional, TextIO, Tuple, Union, overload
 
 from .json_parser import JSONParser, JSONReturnType
+
+
+@overload
+def repair_json(
+    json_str: str = "",
+    return_objects: Literal[False] = False,
+    skip_json_loads: bool = False,
+    logging: bool = False,
+    json_fd: Optional[TextIO] = None,
+    ensure_ascii: bool = True,
+    chunk_length: int = 0,
+    stream_stable: bool = False,
+) -> str: ...
+
+
+@overload
+def repair_json(
+    json_str: str = "",
+    return_objects: Literal[True] = True,
+    skip_json_loads: bool = False,
+    logging: bool = False,
+    json_fd: Optional[TextIO] = None,
+    ensure_ascii: bool = True,
+    chunk_length: int = 0,
+    stream_stable: bool = False,
+) -> Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]]]: ...
 
 
 def repair_json(
@@ -78,7 +104,7 @@ def loads(
     skip_json_loads: bool = False,
     logging: bool = False,
     stream_stable: bool = False,
-) -> Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]]]:
+) -> Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]], str]:
     """
     This function works like `json.loads()` except that it will fix your JSON in the process.
     It is a wrapper around the `repair_json()` function with `return_objects=True`.
@@ -89,7 +115,7 @@ def loads(
         logging (bool, optional): If True, return a tuple with the repaired json and a log of all repair actions. Defaults to False.
 
     Returns:
-        Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]]]: The repaired JSON object or a tuple with the repaired JSON object and repair log.
+        Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]], str]: The repaired JSON object or a tuple with the repaired JSON object and repair log.
     """
     return repair_json(
         json_str=json_str,


### PR DESCRIPTION
## Proposed changes

Better type hints for LSP

### Current
<img width="685" alt="image" src="https://github.com/user-attachments/assets/c6bbe124-232e-4b6f-9830-a844dc47fbea" />
<img width="926" alt="image" src="https://github.com/user-attachments/assets/c8d0e9e4-c878-4f27-8b4c-cee94b53497b" />

### After
<img width="776" alt="image" src="https://github.com/user-attachments/assets/f440df72-c3fc-454c-beec-5c8a81af8b07" />


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangiucugna/json_repair/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run pre-commit and unit tests and all pass locally with my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
