### PR TITLE
Fix typo in json_parser comment

### DIFF
--- a/src/json_repair/json_parser.py
+++ b/src/json_repair/json_parser.py
@@ -31,7 +31,7 @@ class JSONParser:
         self.context = JsonContext()
         # Use this to log the activity, but only if logging is active
 
-        # This is a trick but a beatiful one. We call self.log in the code over and over even if it's not needed.
+        # This is a trick but a beautiful one. We call self.log in the code over and over even if it's not needed.
         # We could add a guard in the code for each call but that would make this code unreadable, so here's this neat trick
         # Replace self.log with a noop
         self.logging = logging


### PR DESCRIPTION
## Summary
- fix simple comment typo in `JSONParser`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*