### PR TITLE
Fix typo in json_repair docstring

### DIFF
--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -14,7 +14,7 @@ This module will parse the JSON file following the BNF definition:
     <object> ::= '{' [ <member> *(', ' <member>) ] '}' ; A sequence of 'members'
     <member> ::= <string> ': ' <json> ; A pair consisting of a name, and a JSON value
 
-If something is wrong (a missing parantheses or quotes for example) it will use a few simple heuristics to fix the JSON string:
+If something is wrong (a missing parentheses or quotes for example) it will use a few simple heuristics to fix the JSON string:
 - Add the missing parentheses if the parser believes that the array or object should be closed
 - Quote strings or add missing single quotes
 - Adjust whitespaces and remove line breaks


### PR DESCRIPTION
## Summary
- fix a minor typo in the json_repair module docstring

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement build)*
- `pre-commit run --files src/json_repair/json_repair.py` *(fails: pre-commit: command not found)*
- `pytest -q` *(fails: pytest: command not found)*