### PR TITLE
Fix variable initialization in parser

### DIFF
--- a/src/json_repair/json_parser.py
+++ b/src/json_repair/json_parser.py
@@ -709,7 +709,7 @@ class JSONParser:
         # <boolean> is one of the literal strings 'true', 'false', or 'null' (unquoted)
         starting_index = self.index
         char = (self.get_char_at() or "").lower()
-        value: tuple[str, bool | None] | None
+        value: tuple[str, bool | None] | None = None
         if char == "t":
             value = ("true", True)
         elif char == "f":


### PR DESCRIPTION
## Summary
- initialize `value` in `parse_boolean_or_null`

## Testing
- `pre-commit run --files src/json_repair/json_parser.py` *(fails: command not found)*
- `python -m pytest -q` *(fails: No module named pytest)*