### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,8 @@
 name: Pytest and Coverage
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push: 


### PR DESCRIPTION
Potential fix for [https://github.com/mangiucugna/json_repair/security/code-scanning/8](https://github.com/mangiucugna/json_repair/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents (e.g., to install dependencies and run tests), we will set `contents: read`. This ensures the workflow adheres to the principle of least privilege and does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
