### PR TITLE
Fix unclosed array followed by object field

### DIFF
--- a/src/json_repair/json_parser.py
+++ b/src/json_repair/json_parser.py
@@ -231,6 +231,16 @@ class JSONParser:
         char = self.get_char_at()
         while char and char not in ["]", "}"]:
             self.skip_whitespaces_at()
+            char = self.get_char_at()
+            if char in self.STRING_DELIMITERS:
+                closing = self.skip_to_character(character=char, idx=1)
+                next_c = self.get_char_at(closing + 1)
+                if next_c == ":":
+                    self.json_str = (
+                        self.json_str[: self.index] + "]}" + self.json_str[self.index :]
+                    )
+                    char = "]"
+                    break
             value = self.parse_json()
 
             # It is possible that parse_json() returns nothing valid, so we increase by 1

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -390,6 +390,32 @@ def test_multiple_jsons():
     )
 
 
+def test_unclosed_array_before_object_field():
+    original = (
+        '{"query":{"dimensions":["a"],"filters":{"connector":"and","filterGroups":'
+        '[{"connector":"and","filters":[]},'
+        '"range":{"starting_time":"2025-05-21T10:19:04.219Z",'
+        '"ending_time":"2025-05-21T10:19:04.219Z"}'
+        ']}}'
+    )
+    expected = {
+        "query": {
+            "dimensions": ["a"],
+            "filters": {
+                "connector": "and",
+                "filterGroups": [
+                    {"connector": "and", "filters": []}
+                ],
+            },
+            "range": {
+                "starting_time": "2025-05-21T10:19:04.219Z",
+                "ending_time": "2025-05-21T10:19:04.219Z",
+            },
+        }
+    }
+    assert repair_json(original, return_objects=True) == expected
+
+
 def test_repair_json_with_objects():
     # Test with valid JSON strings
     assert repair_json("[]", return_objects=True) == []


### PR DESCRIPTION
## Summary
- detect object field after unfinished array and insert `]}`
- cover this case with a regression test

## Testing
- `pytest tests/test_json_repair.py::test_unclosed_array_before_object_field -q`
- `pytest tests/test_json_repair.py -q`