### PR TITLE
Update repair_json for logging is True

### DIFF
--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -74,7 +74,7 @@ def repair_json(
         json_str (str, optional): The JSON string to repair. Defaults to an empty string.
         return_objects (bool, optional): If True, return the decoded data structure. Defaults to False.
         skip_json_loads (bool, optional): If True, skip calling the built-in json.loads() function to verify that the json is valid before attempting to repair. Defaults to False.
-        logging (bool, optional): If True, return a tuple with the repaired json and a log of all repair actions. Defaults to False.
+        logging (bool, optional): If True, return a tuple with the repaired json and a log of all repair actions. Defaults to False. When no repairs where required, the repair log will be an empty list.
         json_fd (Optional[TextIO], optional): File descriptor for JSON input. Do not use! Use `from_file` or `load` instead. Defaults to None.
         ensure_ascii (bool, optional): Set to False to avoid converting non-latin characters to ascii (for example when using chinese characters). Defaults to True. Ignored if `skip_json_loads` is True.
         chunk_length (int, optional): Size in bytes of the file chunks to read at once. Ignored if `json_fd` is None. Do not use! Use `from_file` or `load` instead. Defaults to 1MB.
@@ -93,6 +93,10 @@ def repair_json(
     # It's useful to return the actual object instead of the json string,
     # it allows this lib to be a replacement of the json library
     if return_objects or logging:
+        # If logging is True, the user should expect a tuple.
+        # If json.load(s) worked, the repair log list is empty
+        if logging and isinstance(parsed_json, tuple) is False:
+            return parsed_json, []
         return parsed_json
     # Avoid returning only a pair of quotes if it's an empty string
     elif parsed_json == "":

--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -74,13 +74,13 @@ def repair_json(
         json_str (str, optional): The JSON string to repair. Defaults to an empty string.
         return_objects (bool, optional): If True, return the decoded data structure. Defaults to False.
         skip_json_loads (bool, optional): If True, skip calling the built-in json.loads() function to verify that the json is valid before attempting to repair. Defaults to False.
-        logging (bool, optional): If True, return a tuple with the repaired json and a log of all repair actions. Defaults to False. When no repairs where required, the repair log will be an empty list.
+        logging (bool, optional): If True, return a tuple with the repaired json and a log of all repair actions. Defaults to False. When no repairs were required, the repair log will be an empty list.
         json_fd (Optional[TextIO], optional): File descriptor for JSON input. Do not use! Use `from_file` or `load` instead. Defaults to None.
         ensure_ascii (bool, optional): Set to False to avoid converting non-latin characters to ascii (for example when using chinese characters). Defaults to True. Ignored if `skip_json_loads` is True.
         chunk_length (int, optional): Size in bytes of the file chunks to read at once. Ignored if `json_fd` is None. Do not use! Use `from_file` or `load` instead. Defaults to 1MB.
         stream_stable (bool, optional): When the json to be repaired is the accumulation of streaming json at a certain moment.If this parameter to True will keep the repair results stable.
     Returns:
-        Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]]]: The repaired JSON or a tuple with the repaired JSON and repair log.
+        Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]]]: The repaired JSON or a tuple with the repaired JSON and repair log when logging is True.
     """
     parser = JSONParser(json_str, json_fd, logging, chunk_length, stream_stable)
     if skip_json_loads:


### PR DESCRIPTION
## Summary

This PR standardizes the return type when `logging=True` to ensure consistent behavior regardless of whether repairs were needed.

## Problem

Currently, when `logging=True`, the function returns inconsistent types:
- If repairs were needed: `tuple[JSONReturnType, list[dict[str, str]]]`
- If no repairs were needed: `JSONReturnType`

This inconsistency forces users to check the return type before accessing the repair log, making the API harder to use.

## Solution

When `logging=True`, the function now always returns a tuple with the parsed JSON and a repair log. If no repairs were required, an empty list is returned as the log.

**Benefits:**
- Consistent return type when `logging=True`
- Simplified error handling and type checking for users
- Backward compatible (existing code will continue to work)

## Changes

- Updated the `logging` parameter docstring to clarify that an empty list is returned when no repairs are needed
- Modified the function logic to return `(parsed_json, [])` when `logging=True` but no repairs were performed
- Updated the return type documentation for clarity

## Testing

This change is backward compatible. Existing code that checks for tuple types or handles both return scenarios will continue to work without modification.
