### PR TITLE
feat: add enable_shape_fixes and drop_invalid_items options for schema-guided repair

### DIFF
--- a/src/json_repair/json_repair.py
+++ b/src/json_repair/json_repair.py
@@ -44,6 +44,8 @@ def repair_json(
     stream_stable: bool = False,
     strict: bool = False,
     schema: Any | None = None,
+    enable_shape_fixes: bool = False,
+    drop_invalid_items: bool = False,
     **json_dumps_args: Any,
 ) -> str: ...
 
@@ -59,6 +61,8 @@ def repair_json(
     stream_stable: bool = False,
     strict: bool = False,
     schema: Any | None = None,
+    enable_shape_fixes: bool = False,
+    drop_invalid_items: bool = False,
     **json_dumps_args: Any,
 ) -> JSONReturnType | tuple[JSONReturnType, list[dict[str, str]]]: ...
 
@@ -73,6 +77,8 @@ def repair_json(
     stream_stable: bool = False,
     strict: bool = False,
     schema: Any | None = None,
+    enable_shape_fixes: bool = False,
+    drop_invalid_items: bool = False,
     **json_dumps_args: Any,
 ) -> JSONReturnType | tuple[JSONReturnType, list[dict[str, str]]]:
     """
@@ -89,6 +95,8 @@ def repair_json(
         stream_stable (bool, optional): When the json to be repaired is the accumulation of streaming json at a certain moment.If this parameter to True will keep the repair results stable.
         strict (bool, optional): If True, surface structural problems (duplicate keys, missing separators, empty keys/values, etc.) as ValueError instead of repairing them.
         schema (Any, optional): JSON Schema dict, boolean schema, or pydantic v2 model used to guide repairs and validation for both valid and invalid JSON inputs.
+        enable_shape_fixes (bool, optional): When True and a schema is provided, enable structural heuristics such as mapping a list to an object or unwrapping a single-key wrapper dict. Defaults to False.
+        drop_invalid_items (bool, optional): When True and a schema is provided, array items that cannot be repaired to match the items schema are silently dropped instead of raising. Defaults to False.
     Returns:
         Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]]]: The repaired JSON or a tuple with the repaired JSON and repair log when logging is True.
     """
@@ -98,7 +106,7 @@ def repair_json(
 
     parser = JSONParser(json_str, json_fd, logging, chunk_length, stream_stable, strict)
     schema_obj = schema_from_input(schema) if schema is not None else None
-    repairer = SchemaRepairer(schema_obj, parser.logger if logging else None) if schema_obj is not None else None
+    repairer = SchemaRepairer(schema_obj, parser.logger if logging else None, enable_shape_fixes=enable_shape_fixes, drop_invalid_items=drop_invalid_items) if schema_obj is not None else None
 
     # Fast path for valid JSON: schema-aware mode still applies repair+validation.
     parsed_json: JSONReturnType = None
@@ -140,6 +148,8 @@ def loads(
     stream_stable: bool = False,
     strict: bool = False,
     schema: Any | None = None,
+    enable_shape_fixes: bool = False,
+    drop_invalid_items: bool = False,
 ) -> JSONReturnType | tuple[JSONReturnType, list[dict[str, str]]] | str:
     """
     This function works like `json.loads()` except that it will fix your JSON in the process.
@@ -151,6 +161,8 @@ def loads(
         logging (bool, optional): If True, return a tuple with the repaired json and a log of all repair actions. Defaults to False.
         strict (bool, optional): If True, surface structural problems (duplicate keys, missing separators, empty keys/values, etc.) as ValueError instead of repairing them.
         schema (Any, optional): JSON Schema dict, boolean schema, or pydantic v2 model used to guide repairs and validation for both valid and invalid JSON inputs.
+        enable_shape_fixes (bool, optional): When True and a schema is provided, enable structural heuristics. Defaults to False.
+        drop_invalid_items (bool, optional): When True and a schema is provided, drop array items that cannot be repaired. Defaults to False.
 
     Returns:
         Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]], str]: The repaired JSON object or a tuple with the repaired JSON object and repair log.
@@ -163,6 +175,8 @@ def loads(
         stream_stable=stream_stable,
         strict=strict,
         schema=schema,
+        enable_shape_fixes=enable_shape_fixes,
+        drop_invalid_items=drop_invalid_items,
     )
 
 
@@ -173,6 +187,8 @@ def load(
     chunk_length: int = 0,
     strict: bool = False,
     schema: Any | None = None,
+    enable_shape_fixes: bool = False,
+    drop_invalid_items: bool = False,
 ) -> JSONReturnType | tuple[JSONReturnType, list[dict[str, str]]]:
     """
     This function works like `json.load()` except that it will fix your JSON in the process.
@@ -185,6 +201,8 @@ def load(
         chunk_length (int, optional): Size in bytes of the file chunks to read at once. Defaults to 1MB.
         strict (bool, optional): If True, surface structural problems (duplicate keys, missing separators, empty keys/values, etc.) as ValueError instead of repairing them.
         schema (Any, optional): JSON Schema dict, boolean schema, or pydantic v2 model used to guide repairs and validation for both valid and invalid JSON inputs.
+        enable_shape_fixes (bool, optional): When True and a schema is provided, enable structural heuristics. Defaults to False.
+        drop_invalid_items (bool, optional): When True and a schema is provided, drop array items that cannot be repaired. Defaults to False.
 
     Returns:
         Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]]]: The repaired JSON object or a tuple with the repaired JSON object and repair log.
@@ -197,6 +215,8 @@ def load(
         logging=logging,
         strict=strict,
         schema=schema,
+        enable_shape_fixes=enable_shape_fixes,
+        drop_invalid_items=drop_invalid_items,
     )
 
 
@@ -207,6 +227,8 @@ def from_file(
     chunk_length: int = 0,
     strict: bool = False,
     schema: Any | None = None,
+    enable_shape_fixes: bool = False,
+    drop_invalid_items: bool = False,
 ) -> JSONReturnType | tuple[JSONReturnType, list[dict[str, str]]]:
     """
     This function is a wrapper around `load()` so you can pass the filename as string
@@ -218,6 +240,8 @@ def from_file(
         chunk_length (int, optional): Size in bytes of the file chunks to read at once. Defaults to 1MB.
         strict (bool, optional): If True, surface structural problems (duplicate keys, missing separators, empty keys/values, etc.) as ValueError instead of repairing them.
         schema (Any, optional): JSON Schema dict, boolean schema, or pydantic v2 model used to guide repairs and validation for both valid and invalid JSON inputs.
+        enable_shape_fixes (bool, optional): When True and a schema is provided, enable structural heuristics. Defaults to False.
+        drop_invalid_items (bool, optional): When True and a schema is provided, drop array items that cannot be repaired. Defaults to False.
 
     Returns:
         Union[JSONReturnType, Tuple[JSONReturnType, List[Dict[str, str]]]]: The repaired JSON object or a tuple with the repaired JSON object and repair log.
@@ -230,6 +254,8 @@ def from_file(
             chunk_length=chunk_length,
             strict=strict,
             schema=schema,
+            enable_shape_fixes=enable_shape_fixes,
+            drop_invalid_items=drop_invalid_items,
         )
 
 
@@ -309,6 +335,16 @@ def cli(inline_args: list[str] | None = None) -> int:
         action="store_true",
         help="Raise on duplicate keys, missing separators, empty keys/values, and other unrecoverable structures instead of repairing them",
     )
+    parser.add_argument(
+        "--enable-shape-fixes",
+        action="store_true",
+        help="Enable structural heuristics (list-to-object mapping, single-key unwrapping) when a schema is provided",
+    )
+    parser.add_argument(
+        "--drop-invalid-items",
+        action="store_true",
+        help="Drop array items that cannot be repaired to match the schema instead of raising an error",
+    )
 
     args = parser.parse_args(inline_args)
 
@@ -346,6 +382,8 @@ def cli(inline_args: list[str] | None = None) -> int:
                 skip_json_loads=args.skip_json_loads,
                 strict=args.strict,
                 schema=schema,
+                enable_shape_fixes=args.enable_shape_fixes,
+                drop_invalid_items=args.drop_invalid_items,
             )
         else:
             data = sys.stdin.read()
@@ -354,6 +392,8 @@ def cli(inline_args: list[str] | None = None) -> int:
                 skip_json_loads=args.skip_json_loads,
                 strict=args.strict,
                 schema=schema,
+                enable_shape_fixes=args.enable_shape_fixes,
+                drop_invalid_items=args.drop_invalid_items,
             )
         if args.inline or args.output:
             with Path(args.output or args.filename).open(mode="w") as fd:

--- a/src/json_repair/parse_object.py
+++ b/src/json_repair/parse_object.py
@@ -42,22 +42,6 @@ def parse_object(
                 additional_properties = schema.get("additionalProperties", None)
                 required = set(schema.get("required", []))
 
-    def finalize_obj() -> dict[str, JSONReturnType]:
-        if schema_repairer is None:
-            return obj
-        schema_repairer_local = schema_repairer
-        # Enforce required fields and insert defaults for optional properties.
-        missing_required = [key for key in required if key not in obj]
-        if missing_required:
-            raise ValueError(f"Missing required properties at {path}: {', '.join(missing_required)}")
-        for key, prop_schema in properties.items():
-            if key in obj or key in required:
-                continue
-            if isinstance(prop_schema, dict) and "default" in prop_schema:
-                obj[key] = schema_repairer_local._copy_json_value(prop_schema["default"], f"{path}.{key}", "default")
-                schema_repairer_local._log("Inserted default value for missing property", f"{path}.{key}")
-        return obj
-
     # Stop when you either find the closing parentheses or you have iterated over the entire string
     while (self.get_char_at() or "}") != "}":
         # This is what we expect to find:
@@ -301,11 +285,11 @@ def parse_object(
 
     self.skip_whitespaces()
     if self.get_char_at() != ",":
-        return finalize_obj()
+        return obj
     self.index += 1
     self.skip_whitespaces()
     if self.get_char_at() not in STRING_DELIMITERS:
-        return finalize_obj()
+        return obj
     if not self.strict:
         self.log(
             "Found a comma and string delimiter after object closing brace, checking for additional key-value pairs",
@@ -314,4 +298,4 @@ def parse_object(
         if isinstance(additional_obj, dict):
             obj.update(additional_obj)
 
-    return finalize_obj()
+    return obj

--- a/src/json_repair/schema_repair.py
+++ b/src/json_repair/schema_repair.py
@@ -85,9 +85,17 @@ def schema_from_input(schema: Any) -> dict[str, Any] | bool:
 
 
 class SchemaRepairer:
-    def __init__(self, schema: dict[str, Any] | bool, log: list[dict[str, str]] | None) -> None:
+    def __init__(
+        self,
+        schema: dict[str, Any] | bool,
+        log: list[dict[str, str]] | None,
+        enable_shape_fixes: bool = False,
+        drop_invalid_items: bool = False,
+    ) -> None:
         self.root_schema = schema
         self.log = log
+        self.enable_shape_fixes = enable_shape_fixes
+        self.drop_invalid_items = drop_invalid_items
 
     def _log(self, text: str, path: str) -> None:
         if self.log is not None:
@@ -238,6 +246,14 @@ class SchemaRepairer:
     def _repair_array(self, value: Any, schema: dict[str, Any], path: str) -> JSONReturnType:
         if isinstance(value, list):
             items: list[JSONReturnType] = value
+        elif self.enable_shape_fixes and isinstance(value, dict) and len(value) == 1:
+            sole_value = next(iter(value.values()))
+            if isinstance(sole_value, list):
+                self._log("Unwrapped single-key object to array", path)
+                items = sole_value
+            else:
+                self._log("Wrapped value in array to match schema", path)
+                items = [normalize_missing_values(value)]
         else:
             self._log("Wrapped value in array to match schema", path)
             items = [normalize_missing_values(value)]
@@ -262,7 +278,16 @@ class SchemaRepairer:
                             self._log("Dropped extra array item not covered by schema", f"{path}[{offset}]")
                 items = repaired_items
             else:
-                items = [self.repair_value(item, items_schema, f"{path}[{idx}]") for idx, item in enumerate(items)]
+                if self.drop_invalid_items:
+                    valid_items: list[JSONReturnType] = []
+                    for idx, item in enumerate(items):
+                        try:
+                            valid_items.append(self.repair_value(item, items_schema, f"{path}[{idx}]"))
+                        except ValueError:
+                            self._log("Dropped invalid array item that could not be repaired", f"{path}[{idx}]")
+                    items = valid_items
+                else:
+                    items = [self.repair_value(item, items_schema, f"{path}[{idx}]") for idx, item in enumerate(items)]
         min_items = schema.get("minItems")
         if min_items is not None and len(items) < min_items:
             raise ValueError(f"Array at {path} does not meet minItems.")
@@ -270,7 +295,19 @@ class SchemaRepairer:
 
     def _repair_object(self, value: Any, schema: dict[str, Any], path: str) -> JSONReturnType:
         if not isinstance(value, dict):
-            raise ValueError(f"Expected object at {path}, got {type(value).__name__}.")
+            if self.enable_shape_fixes and isinstance(value, list):
+                mapped = self._map_list_to_object(value, schema, path)
+                if mapped is not None:
+                    value = mapped
+            if not isinstance(value, dict):
+                raise ValueError(f"Expected object at {path}, got {type(value).__name__}.")
+
+        # When shape fixes are enabled, unwrap {"wrapper_key": {...}} to the inner dict
+        # if the outer key isn't a schema property and the inner dict has all required keys.
+        if self.enable_shape_fixes:
+            unwrapped = self._try_unwrap_single_key(value, schema, path)
+            if unwrapped is not None:
+                value = unwrapped
 
         properties = schema.get("properties", {})
         if not isinstance(properties, dict):
@@ -281,7 +318,10 @@ class SchemaRepairer:
             pattern_properties = {}
         additional_properties = schema.get("additionalProperties")
 
-        missing_required = [key for key in required if key not in value]
+        missing_required = [
+            key for key in required
+            if key not in value and not (isinstance(properties.get(key), dict) and "default" in properties[key])
+        ]
         if missing_required:
             raise ValueError(f"Missing required properties at {path}: {', '.join(missing_required)}")
 
@@ -291,7 +331,7 @@ class SchemaRepairer:
             key_path = f"{path}.{key}"
             if key in value:
                 repaired[key] = self.repair_value(value[key], prop_schema, key_path)
-            elif isinstance(prop_schema, dict) and "default" in prop_schema and key not in required:
+            elif isinstance(prop_schema, dict) and "default" in prop_schema:
                 repaired[key] = self._copy_json_value(prop_schema["default"], key_path, "default")
                 self._log("Inserted default value for missing property", key_path)
 
@@ -378,6 +418,13 @@ class SchemaRepairer:
         raise ValueError(f"Cannot infer missing value at {path}.")
 
     def _coerce_scalar(self, value: Any, schema_type: str, path: str) -> JSONReturnType:
+        # Shape fix: unwrap single-key dict when expecting a scalar type
+        if self.enable_shape_fixes and isinstance(value, dict) and len(value) == 1:
+            sole_value = next(iter(value.values()))
+            if not isinstance(sole_value, (dict, list)):
+                self._log("Unwrapped single-key object to scalar value", path)
+                value = sole_value
+
         if schema_type == "string":
             if isinstance(value, str):
                 return value
@@ -433,9 +480,15 @@ class SchemaRepairer:
                 return value
             if isinstance(value, str):
                 lowered = value.lower()
-                if lowered in ("true", "false"):
+                if lowered in ("true", "yes", "1"):
                     self._log("Coerced string to boolean", path)
-                    return lowered == "true"
+                    return True
+                if lowered in ("false", "no", "0"):
+                    self._log("Coerced string to boolean", path)
+                    return False
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                self._log("Coerced number to boolean", path)
+                return bool(value)
             raise ValueError(f"Expected boolean at {path}.")
 
         if schema_type == "null":
@@ -483,6 +536,94 @@ class SchemaRepairer:
                 copied[key] = self._copy_json_value(item, f"{path}.{key}", label)
             return copied
         raise ValueError(f"{label.capitalize()} value at {path} is not JSON compatible.")
+
+    def _map_list_to_object(
+        self, value: list[Any], schema: dict[str, Any], path: str
+    ) -> dict[str, JSONReturnType] | None:
+        """Cautiously map a top-level list into an object when the schema expects one.
+
+        Each list element is matched to a schema property by type. An element is only
+        mapped when exactly one unambiguous candidate property exists. Returns ``None``
+        if no safe mapping can be produced.
+        """
+        properties = schema.get("properties", {})
+        if not isinstance(properties, dict) or not properties:
+            return None
+
+        mapped: dict[str, JSONReturnType] = {}
+        used_props: set[str] = set()
+
+        for element in value:
+            candidates: list[str] = []
+            for pname, pschema in properties.items():
+                if pname in used_props:
+                    continue
+                resolved = self.resolve_schema(pschema)
+                if not isinstance(resolved, dict):
+                    continue
+                if self._element_matches_property(element, resolved):
+                    candidates.append(pname)
+
+            if len(candidates) == 1:
+                pname = candidates[0]
+                mapped[pname] = element
+                used_props.add(pname)
+            else:
+                self._log(
+                    f"List-to-object mapping: {'ambiguous' if candidates else 'no'} match for element",
+                    path,
+                )
+
+        if not mapped:
+            return None
+        self._log("Mapped list to object using schema property types", path)
+        return mapped
+
+    def _element_matches_property(self, element: Any, resolved: dict[str, Any]) -> bool:
+        """Check whether a list element's Python type aligns with a resolved property schema."""
+        if isinstance(element, dict):
+            if not (resolved.get("type") == "object" or self.is_object_schema(resolved)):
+                return False
+            props = resolved.get("properties")
+            expected_keys = set(props.keys()) if isinstance(props, dict) else set()
+            return bool(expected_keys) and set(element.keys()).issubset(expected_keys)
+        if isinstance(element, list):
+            return resolved.get("type") == "array" or self.is_array_schema(resolved)
+        # bool must be checked before int/float because isinstance(True, int) is True
+        if isinstance(element, bool):
+            return resolved.get("type") == "boolean"
+        if isinstance(element, str):
+            return resolved.get("type") == "string"
+        if isinstance(element, (int, float)):
+            return resolved.get("type") in ("number", "integer")
+        return False
+
+    def _try_unwrap_single_key(
+        self, value: dict[str, Any], schema: dict[str, Any], path: str
+    ) -> dict[str, Any] | None:
+        """Unwrap ``{"wrapper": {...}}`` to the inner dict when it better matches the schema.
+
+        Fires only when the outer dict has exactly one key that is NOT a schema property,
+        and the inner value is a dict containing all required keys.
+        """
+        if len(value) != 1:
+            return None
+
+        properties = schema.get("properties", {})
+        if not isinstance(properties, dict):
+            properties = {}
+        required = set(schema.get("required", []))
+
+        outer_key, inner = next(iter(value.items()))
+        if outer_key in properties:
+            return None
+        if not isinstance(inner, dict):
+            return None
+        if required and not required.issubset(set(inner.keys())):
+            return None
+
+        self._log(f"Unwrapped single-key object '{outer_key}' to match flat object schema", path)
+        return inner
 
     def _prepare_schema_for_validation(self, schema: object) -> dict[str, Any]:
         def normalize(node: Any) -> Any:

--- a/tests/test_schema_guided_parse.py
+++ b/tests/test_schema_guided_parse.py
@@ -34,11 +34,21 @@ def test_schema_guides_missing_value_type_defaults():
     }
 
 
-def test_schema_missing_required_property_raises():
+def test_schema_missing_required_property_with_default_is_filled():
     pytest.importorskip("jsonschema")
     schema = {
         "type": "object",
         "properties": {"required_value": {"type": "integer", "default": 1}},
+        "required": ["required_value"],
+    }
+    assert repair_with_schema("{}", schema) == {"required_value": 1}
+
+
+def test_schema_missing_required_property_without_default_raises():
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {"required_value": {"type": "integer"}},
         "required": ["required_value"],
     }
     with pytest.raises(ValueError, match="Missing required properties"):

--- a/tests/test_schema_repairer.py
+++ b/tests/test_schema_repairer.py
@@ -357,8 +357,18 @@ def test_fill_missing_and_coerce_scalar_paths():
         repairer._coerce_scalar("nope", "number", "$")
     with pytest.raises(ValueError, match="Expected number"):
         repairer._coerce_scalar([], "number", "$")
+    assert repairer._coerce_scalar("yes", "boolean", "$") is True
+    assert repairer._coerce_scalar("Yes", "boolean", "$") is True
+    assert repairer._coerce_scalar("no", "boolean", "$") is False
+    assert repairer._coerce_scalar("No", "boolean", "$") is False
+    assert repairer._coerce_scalar("1", "boolean", "$") is True
+    assert repairer._coerce_scalar("0", "boolean", "$") is False
+    assert repairer._coerce_scalar(1, "boolean", "$") is True
+    assert repairer._coerce_scalar(0, "boolean", "$") is False
+    assert repairer._coerce_scalar(3.14, "boolean", "$") is True
+    assert repairer._coerce_scalar(0.0, "boolean", "$") is False
     with pytest.raises(ValueError, match="Expected boolean"):
-        repairer._coerce_scalar("yes", "boolean", "$")
+        repairer._coerce_scalar([], "boolean", "$")
     with pytest.raises(ValueError, match="Expected null"):
         repairer._coerce_scalar("x", "null", "$")
     with pytest.raises(ValueError, match="Unsupported schema type"):
@@ -382,3 +392,502 @@ def test_apply_enum_const_mismatch_raises():
 
 def test_repair_json_valid_empty_string_returns_empty():
     assert repair_json('""') == ""
+
+
+def test_map_list_to_object_unambiguous():
+    """List elements are mapped to object properties when exactly one candidate exists."""
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "meta": {
+                "type": "object",
+                "properties": {"k": {"type": "string"}},
+            },
+        },
+    }
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    # Each element type has exactly one matching property.
+    value = ["hello", ["a", "b"], {"k": "v"}]
+    result = repairer.repair_value(value, schema, "$")
+    assert result == {"name": "hello", "tags": ["a", "b"], "meta": {"k": "v"}}
+
+
+def test_map_list_to_object_ambiguous_returns_error():
+    """When multiple candidates match, the mapping is ambiguous and we raise."""
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {
+            "first_name": {"type": "string"},
+            "last_name": {"type": "string"},
+        },
+    }
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    # Two string properties → ambiguous for a single string element.
+    with pytest.raises(ValueError, match="Expected object"):
+        repairer.repair_value(["hello"], schema, "$")
+
+
+def test_map_list_to_object_number_and_bool():
+    """Number and boolean elements are mapped to appropriate schema properties."""
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {
+            "count": {"type": "integer"},
+            "active": {"type": "boolean"},
+        },
+    }
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    result = repairer.repair_value([42, True], schema, "$")
+    assert result == {"count": 42, "active": True}
+
+
+def test_map_list_to_object_disabled_by_default():
+    """Without enable_shape_fixes, list→object mapping does not happen."""
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+    }
+    repairer = SchemaRepairer(schema, [])
+    with pytest.raises(ValueError, match="Expected object"):
+        repairer.repair_value(["hello"], schema, "$")
+
+
+def test_map_list_to_object_empty_properties():
+    """When schema has no properties, list mapping returns None and raises."""
+    schema = {"type": "object"}
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    with pytest.raises(ValueError, match="Expected object"):
+        repairer.repair_value(["hello"], schema, "$")
+
+
+def test_unwrap_single_key_object():
+    """A single-key wrapper dict is unwrapped when the inner dict has all required keys."""
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+        },
+        "required": ["name", "age"],
+    }
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    value = {"result": {"name": "Alice", "age": 30}}
+    result = repairer.repair_value(value, schema, "$")
+    assert result == {"name": "Alice", "age": 30}
+
+
+def test_unwrap_single_key_object_outer_key_is_property():
+    """No unwrapping when the outer key is a declared schema property."""
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "object"},
+        },
+    }
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    value = {"name": {"inner": "data"}}
+    # "name" IS a property, so no unwrapping; should repair normally.
+    result = repairer.repair_value(value, schema, "$")
+    assert result == {"name": {"inner": "data"}}
+
+
+def test_unwrap_single_key_object_missing_required():
+    """No unwrapping when the inner dict is missing required keys."""
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+        },
+        "required": ["name", "age"],
+    }
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    # Inner dict only has "name", missing "age" → no unwrap, treated as missing required.
+    with pytest.raises(ValueError, match="Missing required properties"):
+        repairer.repair_value({"wrapper": {"name": "Alice"}}, schema, "$")
+
+
+def test_unwrap_single_key_object_multi_key():
+    """No unwrapping when the dict has multiple keys."""
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "string"}, "b": {"type": "string"}},
+        "required": ["a", "b"],
+    }
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    value = {"a": "x", "b": "y"}
+    result = repairer.repair_value(value, schema, "$")
+    assert result == {"a": "x", "b": "y"}
+
+
+def test_unwrap_single_key_inner_not_dict():
+    """No unwrapping when the inner value is not a dict."""
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    with pytest.raises(ValueError, match="Missing required properties"):
+        repairer.repair_value({"wrapper": "not-a-dict"}, schema, "$")
+
+
+def test_unwrap_disabled_by_default():
+    """Without enable_shape_fixes, single-key unwrapping does not happen."""
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+        "required": ["name", "age"],
+    }
+    repairer = SchemaRepairer(schema, [])
+    with pytest.raises(ValueError, match="Missing required properties"):
+        repairer.repair_value({"result": {"name": "Alice", "age": 30}}, schema, "$")
+
+
+def test_shape_fixes_via_repair_json_fast_path():
+    """Shape fixes work through the full repair_json API on the fast path (valid JSON)."""
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+        },
+        "required": ["name", "age"],
+    }
+    # Valid JSON (parseable by json.loads), but wrong shape — needs unwrapping.
+    raw = '{"result": {"name": "Alice", "age": 30}}'
+    result = repair_json(raw, return_objects=True, schema=schema, enable_shape_fixes=True)
+    assert result == {"name": "Alice", "age": 30}
+
+
+def test_shape_fixes_via_repair_json_skip_json_loads():
+    """Shape fixes work through the full repair_json API on the parser path."""
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "tags": {"type": "array", "items": {"type": "string"}},
+        },
+    }
+    raw = '["hello", ["a", "b"]]'
+    result = repair_json(raw, return_objects=True, schema=schema, enable_shape_fixes=True, skip_json_loads=True)
+    assert result == {"name": "hello", "tags": ["a", "b"]}
+
+
+def test_shape_fixes_logging():
+    """Shape-fix log entries appear when logging is enabled."""
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+        },
+        "required": ["name", "age"],
+    }
+    raw = '{"wrapper": {"name": "Alice", "age": 30}}'
+    result, logs = repair_json(raw, return_objects=True, schema=schema, enable_shape_fixes=True, logging=True)
+    assert result == {"name": "Alice", "age": 30}
+    log_texts = [entry["text"] for entry in logs]
+    assert any("Unwrapped" in t for t in log_texts)
+
+
+def test_array_invalid_items_raise_by_default():
+    """By default, array items that cannot be repaired raise instead of being dropped."""
+    repairer = SchemaRepairer({}, [])
+    schema = {"type": "array", "items": {"type": "integer"}}
+    with pytest.raises(ValueError, match="Expected integer"):
+        repairer.repair_value([1, "abc", "3", 4], schema, "$")
+
+
+def test_array_drops_invalid_items_when_enabled():
+    """With drop_invalid_items, array items that cannot be repaired are dropped."""
+    repairer = SchemaRepairer({}, [], drop_invalid_items=True)
+    schema = {"type": "array", "items": {"type": "integer"}}
+    assert repairer.repair_value([1, "abc", "3", 4], schema, "$") == [1, 3, 4]
+
+
+def test_array_drops_invalid_items_logging():
+    """Dropped array items are logged."""
+    log: list[dict[str, str]] = []
+    repairer = SchemaRepairer({}, log, drop_invalid_items=True)
+    schema = {"type": "array", "items": {"type": "integer"}}
+    result = repairer.repair_value([1, "abc", 3], schema, "$")
+    assert result == [1, 3]
+    assert any("Dropped invalid array item" in entry["text"] for entry in log)
+
+
+def test_object_coercion_failure_propagates():
+    """When a property value can't be repaired, the error propagates even if a default exists."""
+    repairer = SchemaRepairer({}, [])
+    schema = {
+        "type": "object",
+        "properties": {
+            "level": {"type": "number", "default": 1},
+        },
+    }
+    with pytest.raises(ValueError, match="Expected number"):
+        repairer.repair_value({"level": "intermediate"}, schema, "$")
+
+
+def test_missing_required_with_default():
+    """Missing required properties that have defaults are filled instead of raising."""
+    repairer = SchemaRepairer({}, [])
+    schema = {
+        "type": "object",
+        "properties": {
+            "id": {"type": "number", "default": 0},
+            "name": {"type": "string"},
+        },
+        "required": ["id", "name"],
+    }
+    result = repairer.repair_value({"name": "test"}, schema, "$")
+    assert result == {"id": 0, "name": "test"}
+
+
+def test_missing_required_without_default_still_raises():
+    """Missing required properties without defaults still raise."""
+    repairer = SchemaRepairer({}, [])
+    schema = {
+        "type": "object",
+        "properties": {
+            "id": {"type": "number"},
+            "name": {"type": "string"},
+        },
+        "required": ["id", "name"],
+    }
+    with pytest.raises(ValueError, match="Missing required properties"):
+        repairer.repair_value({"name": "test"}, schema, "$")
+
+
+def test_shape_fix_unwrap_dict_to_array():
+    """Shape fix: unwrap {key: [...]} to [...] when schema expects array."""
+    schema = {
+        "type": "array",
+        "items": {"type": "string"},
+    }
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    result = repairer.repair_value({"items": ["a", "b", "c"]}, schema, "$")
+    assert result == ["a", "b", "c"]
+
+
+def test_shape_fix_unwrap_dict_to_array_non_list_value():
+    """Shape fix: when dict has one key but value is not a list, wrap dict in an array."""
+    schema = {"type": "array"}
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    # sole value is not a list → falls through to normal wrap behavior
+    result = repairer.repair_value({"key": "value"}, schema, "$")
+    assert result == [{"key": "value"}]
+
+
+def test_shape_fix_unwrap_dict_to_array_disabled():
+    """Without enable_shape_fixes, dict→array unwrapping wraps the dict in an array."""
+    schema = {"type": "array"}
+    repairer = SchemaRepairer(schema, [])
+    result = repairer.repair_value({"items": ["a"]}, schema, "$")
+    assert result == [{"items": ["a"]}]
+
+
+def test_shape_fix_unwrap_dict_to_scalar():
+    """Shape fix: unwrap {key: value} to value when schema expects a scalar type."""
+    schema_str = {"type": "string"}
+    repairer = SchemaRepairer(schema_str, [], enable_shape_fixes=True)
+    assert repairer.repair_value({"result": "hello"}, schema_str, "$") == "hello"
+
+    schema_num = {"type": "number"}
+    repairer_num = SchemaRepairer(schema_num, [], enable_shape_fixes=True)
+    assert repairer_num.repair_value({"count": 42}, schema_num, "$") == 42
+
+    schema_bool = {"type": "boolean"}
+    repairer_bool = SchemaRepairer(schema_bool, [], enable_shape_fixes=True)
+    assert repairer_bool.repair_value({"flag": True}, schema_bool, "$") is True
+
+
+def test_shape_fix_unwrap_dict_to_scalar_with_coercion():
+    """Shape fix unwrapping combined with type coercion."""
+    schema = {"type": "integer"}
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    # Unwraps the dict, then coerces string "42" to integer 42
+    assert repairer.repair_value({"value": "42"}, schema, "$") == 42
+
+
+def test_shape_fix_unwrap_dict_to_scalar_container_not_unwrapped():
+    """Shape fix does not unwrap dicts whose sole value is a container."""
+    schema = {"type": "string"}
+    repairer = SchemaRepairer(schema, [], enable_shape_fixes=True)
+    # sole value is a dict → not unwrapped → raises
+    with pytest.raises(ValueError, match="Expected string"):
+        repairer.repair_value({"result": {"inner": "value"}}, schema, "$")
+    # sole value is a list → not unwrapped → raises
+    with pytest.raises(ValueError, match="Expected string"):
+        repairer.repair_value({"result": [1, 2]}, schema, "$")
+
+
+def test_shape_fix_unwrap_dict_to_scalar_disabled():
+    """Without enable_shape_fixes, dict→scalar unwrapping does not happen."""
+    schema = {"type": "string"}
+    repairer = SchemaRepairer(schema, [])
+    with pytest.raises(ValueError, match="Expected string"):
+        repairer.repair_value({"result": "hello"}, schema, "$")
+
+
+def test_complex_schema_repair_integration():
+    """Complex integration test exercising multiple repair features together,
+    inspired by real-world LLM output repair scenarios."""
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {
+            "user": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "number"},
+                    "name": {"type": "string"},
+                    "active": {"type": "boolean", "default": True},
+                    "profile": {
+                        "type": "object",
+                        "properties": {
+                            "age": {"type": "number"},
+                            "bio": {"type": "string", "default": "No bio provided"},
+                            "level": {"type": "number", "default": 1},
+                        },
+                        "additionalProperties": False,
+                    },
+                    "preferences": {
+                        "type": "object",
+                        "properties": {
+                            "theme": {"type": "string", "default": "light"},
+                            "notifications": {"type": "boolean", "default": True},
+                            "language": {"type": "string", "default": "en"},
+                        },
+                        "additionalProperties": False,
+                    },
+                    "permissions": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "resource": {"type": "string"},
+                                "access_level": {"type": "string"},
+                            },
+                            "required": ["resource", "access_level"],
+                            "additionalProperties": False,
+                        },
+                    },
+                },
+                "required": ["id", "name"],
+                "additionalProperties": False,
+            },
+            "posts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "number", "default": 0},
+                        "title": {"type": "string"},
+                        "content": {"type": "string"},
+                        "published": {"type": "boolean", "default": False},
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                    },
+                    "required": ["id", "title"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        "required": ["user"],
+    }
+    value = {
+        "user": {
+            "id": "123",
+            "name": 456,
+            "extra_field": "remove me",
+            "profile": {
+                "age": "29",
+                "level": "5",
+                "extra": "drop",
+            },
+            "preferences": {
+                "notifications": 0,
+                "extra_pref": "remove",
+            },
+            "permissions": {
+                "resource": "api",
+                "access_level": "read",
+            },
+        },
+        "posts": [
+            {
+                "id": "1",
+                "title": "First Post",
+                "content": 12345,
+                "published": "true",
+                "tags": "tag1",
+            },
+            {
+                "title": "Second Post",
+                "extra_post_field": "remove me",
+            },
+        ],
+    }
+    repairer = SchemaRepairer(schema, [])
+    result = repairer.repair_value(value, schema, "$")
+    expected = {
+        "user": {
+            "id": 123.0,
+            "name": "456",
+            "active": True,
+            "profile": {
+                "age": 29.0,
+                "bio": "No bio provided",
+                "level": 5.0,
+            },
+            "preferences": {
+                "theme": "light",
+                "notifications": False,
+                "language": "en",
+            },
+            "permissions": [{"resource": "api", "access_level": "read"}],
+        },
+        "posts": [
+            {
+                "id": 1.0,
+                "title": "First Post",
+                "content": "12345",
+                "published": True,
+                "tags": ["tag1"],
+            },
+            {"id": 0, "title": "Second Post", "published": False},
+        ],
+    }
+    assert result == expected
+    # Verify the result validates against the schema
+    repairer.validate(result, schema)
+
+
+def test_complex_repair_via_repair_json():
+    """Integration test exercising the full repair_json API with schema-driven repair."""
+    pytest.importorskip("jsonschema")
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "score": {"type": "number"},
+            "active": {"type": "boolean"},
+            "tags": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["name"],
+    }
+    raw = '{"name": 42, "score": "99.5", "active": "yes", "tags": "python"}'
+    result = repair_json(raw, return_objects=True, schema=schema)
+    assert result == {"name": "42", "score": 99.5, "active": True, "tags": ["python"]}


### PR DESCRIPTION
## Summary

Enhance schema-guided repair with structural heuristics, broader coercions, and opt-in lossy array filtering.

- **Shape fixes** (`enable_shape_fixes=True`): new opt-in structural heuristics that handle common LLM output quirks:
  - **List-to-object mapping**: `["hello", ["a","b"]]` → `{"name": "hello", "tags": ["a","b"]}` when each element unambiguously matches exactly one schema property by type.
  - **Single-key object unwrapping** (object → object): `{"result": {"name": "Alice"}}` → `{"name": "Alice"}` when the outer key isn't a schema property and the inner dict has all required keys.
  - **Single-key object unwrapping** (object → array): `{"items": ["a","b"]}` → `["a","b"]` when the schema expects an array.
  - **Single-key object unwrapping** (object → scalar): `{"result": "hello"}` → `"hello"` when the schema expects a scalar type.
- **Extended boolean coercion**: `"yes"`/`"no"`/`"1"`/`"0"` strings are now coerced to booleans (in addition to the existing `"true"`/`"false"`). `int`/`float` values are also coerced (`0` → `False`, non-zero → `True`).
- **Missing required properties with defaults**: required properties that are absent from the input but have a `"default"` in the schema are now filled with the default instead of raising `ValueError`. Properties without defaults still raise.
- **Drop invalid array items** (`drop_invalid_items=True`): new opt-in flag that silently drops array items that cannot be repaired to match the items schema, instead of failing the entire array. Dropped items are logged.
- **Simplify `parse_object.py`**: removed the `finalize_obj` function which duplicated required-property enforcement and default insertion. This logic now lives exclusively in `SchemaRepairer._repair_object`, which runs after parsing via `parse_json`.

## Test plan

- [x] Existing tests pass (123 passed, 1 skipped)
- [x] New tests for extended boolean coercion (`"yes"`, `"no"`, `"1"`, `"0"`, int/float → bool)
- [x] New tests for missing-required-with-default (fills default) and without-default (still raises)
- [x] New tests for `drop_invalid_items` — off by default (raises), on explicitly (drops + logs)
- [x] New tests for shape-fix dict→array and dict→scalar unwrapping (enabled and disabled)
- [x] New tests for list-to-object mapping, single-key object unwrapping (existing + new edge cases)
- [x] Complex integration test exercising nested objects, type coercion, default filling, array wrapping, `additionalProperties` removal, and schema validation of the final result
- [x] End-to-end `repair_json()` integration test with schema